### PR TITLE
🐛 검색 결과가 없을 때 페이지 제대로 나오도록 수정

### DIFF
--- a/src/pages/SearchResultPage.jsx
+++ b/src/pages/SearchResultPage.jsx
@@ -45,8 +45,6 @@ const SearchResultPage = () => {
     }
   };
 
-  if (spaces.length === 0) return null;
-
   return (
     <div style={{ marginTop: "100px" }}>
       <SearchBar />


### PR DESCRIPTION
## 요약

검색 결과가 없을때 빈 페이지가 나오는 버그를 해결하였습니다

## 작업 사항

검색 결과가 없을때 null을 return 하던 걸 삭제하였습니다

---

### 해결한 이슈

closes: #25 
