### PR TITLE
🐛 Vercel 배포시 404 페이지 에러 해결

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+    "rewrites": [
+        {"source": "/(.*)", "destination": "/"}
+    ]
+}


### PR DESCRIPTION
## 요약

Vercel 배포시 새로고침하면 404에러 페이지로 넘어가는 문제를 해결했습니다

## 작업 사항

vercel.json 파일 추가를 통해 문제를 해결

---

### 해결한 이슈

closes: #27 
