### PR TITLE
🐛 공간 상세 본문 줄바꿈이 적용되지 않는 버그 수정

### DIFF
--- a/src/components/AdminSpaceApprovalList.jsx
+++ b/src/components/AdminSpaceApprovalList.jsx
@@ -303,7 +303,9 @@ const AdminSpaceApprovalList = ({ spaces, onApprove, onReject }) => {
               <Typography variant="body1" sx={{ mt: 2 }}>
                 숙소 설명:
               </Typography>
-              <Typography variant="body2">{selectedSpace.content}</Typography>
+              <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                {selectedSpace.content}
+              </Typography>
             </>
           )}
         </Box>

--- a/src/components/HostSpaceList.jsx
+++ b/src/components/HostSpaceList.jsx
@@ -322,7 +322,10 @@ const HostSpaceList = ({ spaces, onEdit, onDelete }) => {
             >
               상세 내용
             </Typography>
-            <Typography id="modal-modal-description" sx={{ mt: 2 }}>
+            <Typography
+              id="modal-modal-description"
+              sx={{ mt: 2, whiteSpace: "pre-wrap" }}
+            >
               {selectedContent}
             </Typography>
           </Box>

--- a/src/components/SpaceDetailContainer.jsx
+++ b/src/components/SpaceDetailContainer.jsx
@@ -302,7 +302,11 @@ const SpaceDetailContainer = ({
 
             <Divider sx={{ my: 3 }} />
 
-            <Typography variant="body1" paragraph>
+            <Typography
+              variant="body1"
+              sx={{ whiteSpace: "pre-wrap" }}
+              paragraph
+            >
               {space.space.content}
             </Typography>
             <Divider sx={{ my: 3 }} />


### PR DESCRIPTION
## 요약

공간 상세 페이지, Admin과 Host의 공간 목록 조회시 공간 상세 본분에 줄바꿈이 적용되지 않는 버그 수정

## 작업 사항

줄바꿈이 적용되도록 CSS 수정하였습니다

---

### 해결한 이슈

closes: #31 
